### PR TITLE
Enable java

### DIFF
--- a/conda-recipes/bmi-java/build.sh
+++ b/conda-recipes/bmi-java/build.sh
@@ -1,0 +1,3 @@
+ant dist
+install -d -m755 $PREFIX/lib
+install -m664 dist/$PKG_NAME.jar $PREFIX/lib

--- a/conda-recipes/bmi-java/meta.yaml
+++ b/conda-recipes/bmi-java/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: bmi-java
+  version: "0.1"
+
+source:
+  git_url: https://github.com/mdpiper/bmi-java

--- a/conda-recipes/cca-babel/build.sh
+++ b/conda-recipes/cca-babel/build.sh
@@ -13,7 +13,7 @@ if [ $(uname) == Darwin ]; then
   export JAVAPREFIX=/usr
 else
   JAVAPREFIX="${JAVA_HOME:-/usr/java/default}"
-  export JAVAPREFIX="/usr/java/default"
+  #export JAVAPREFIX="/usr/java/default"
 fi
 export JAVA=$JAVAPREFIX/bin/java
 
@@ -25,6 +25,6 @@ export F03=$(which gfortran)
 export PYTHON=$PREFIX/bin/python
 export PATH=$JAVAPREFIX/bin:$PATH
 
-./configure --prefix=$PREFIX --disable-documentation --disable-java
+./configure --prefix=$PREFIX --disable-documentation
 make all -j4
 make install


### PR DESCRIPTION
I un-disabled (I love English) java when building Babel, and added a conda recipe for building and installing the `bmi-java` example. 
